### PR TITLE
Allow restricting of columns when replicating table.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - HTTPS_KEY=${SOURCE_KEY}
       - HTTPS_CA_BUNDLE=${TARGET_CRT}
       - REPLICATE_TO=target
-      - REPLICATE_TABLES=test other_table
+      - REPLICATE_TABLES=test other_table|name
     ports:
       - "31415:31415"
       - "31417:31417"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,7 @@ SYNC_URL="${SYNC_URL}"
 REGISTRATION_URL="${REGISTRATION_URL}"
 REPLICATE_TO="${REPLICATE_TO}"
 REPLICATE_TABLES="${REPLICATE_TABLES}"
+REPLICATE_COLS=""
 
 # Build other variables
 HTTP_ENABLE="false"
@@ -174,6 +175,15 @@ EOL
 
 for REPLICATE_TABLE in $REPLICATE_TABLES
 do
+
+if [[ $REPLICATE_TABLE == *"|"* ]]
+then
+  echo 'Found cols in table config'
+  REPLICATE_COLS=${REPLICATE_TABLE#*|}
+  REPLICATE_TABLE=${REPLICATE_TABLE%|*}
+  echo "REPLICATE_TABLE=$REPLICATE_TABLE and REPLICATE_COLS=$REPLICATE_COLS"
+fi
+
 echo "Adding config for $REPLICATE_TABLE in ${DB_TYPE}..."
 cat << EOL >> "init.sql"
 insert into sym_channel
@@ -181,8 +191,8 @@ insert into sym_channel
       values ('${REPLICATE_TABLE}', 10, 1000, 10, 0, 'default', 1);
 
 insert into sym_trigger
-(trigger_id, source_table_name, channel_id, last_update_time, create_time)
-      values ('${REPLICATE_TABLE}', '${REPLICATE_TABLE}', '${REPLICATE_TABLE}', current_timestamp, current_timestamp);
+(trigger_id, source_table_name, channel_id, last_update_time, create_time, included_column_names)
+      values ('${REPLICATE_TABLE}', '${REPLICATE_TABLE}', '${REPLICATE_TABLE}', current_timestamp, current_timestamp, '${REPLICATE_COLS}');
 
 insert into sym_trigger_router
 (trigger_id, router_id, initial_load_order, create_time, last_update_time)


### PR DESCRIPTION
You can now optionally specify a | character with a column name (comma seperated) which will tell symmetric to only replicate those columns from the table name.

For example:

```
REPLICATE_TABLES=test|firstCol,secondCol,fithCol
```

Or you can just repliacte the entire table by just specifying the table name eg:

```
REPLICATE_TABLES=test other_table
```