### PR TITLE
[LEVWEB-983] Add support for SSL on DB connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Configuration is available using environment variables in order to configure the
 ```
 GROUP_ID: <Node Group that this Node is a member of. [SymmetricDSGroups]>
 DB_HOST: <Database host name>
+DB_SSL: Defines whether or not to use SSL/TLS. Set to FALSE to disable. Defaults to TRUE.
+DB_CA: A base64 encoded CA certificate to verify the database's certificate against. If no certificate is provided then the certificate will not be verified.
 DB_TYPE: <Used to tell symmetric what JDBC driver to use. Can be mysql, postgres or oracle. Defaults to postgres.>
 DB_NAME: <Database name>
 DB_USER: <Database user>

--- a/docker-compose-basic-auth.yml
+++ b/docker-compose-basic-auth.yml
@@ -23,6 +23,7 @@ services:
       - HTTPS=FALSE
       - GROUP_ID=target
       - DB_HOST=target
+      - DB_SSL=FALSE
       - DB_TYPE=postgres
       - DB_NAME=target
       - DB_USER=target
@@ -40,6 +41,7 @@ services:
       - HTTPS=FALSE
       - GROUP_ID=target2
       - DB_HOST=target2
+      - DB_SSL=FALSE
       - DB_TYPE=postgres
       - DB_NAME=target2
       - DB_USER=target2

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -15,6 +15,7 @@ services:
       - HTTPS=FALSE
       - GROUP_ID=target
       - DB_HOST=target
+      - DB_SSL=FALSE
       - DB_TYPE=postgres
       - DB_NAME=target
       - DB_USER=target
@@ -31,6 +32,7 @@ services:
       - HTTPS=FALSE
       - GROUP_ID=source
       - DB_HOST=source
+      - DB_SSL=FALSE
       - DB_TYPE=mysql
       - DB_NAME=source
       - DB_USER=root

--- a/docker-compose-oracle-11g.yml
+++ b/docker-compose-oracle-11g.yml
@@ -15,6 +15,7 @@ services:
       - HTTPS=FALSE
       - GROUP_ID=target
       - DB_HOST=target
+      - DB_SSL=FALSE
       - DB_TYPE=postgres
       - DB_NAME=target
       - DB_USER=target
@@ -33,6 +34,7 @@ services:
       - HTTPS=FALSE
       - GROUP_ID=source
       - DB_HOST=source
+      - DB_SSL=FALSE
       - DB_TYPE=oracle
       - DB_NAME=XE
       - DB_USER=source

--- a/docker-compose-oracle.yml
+++ b/docker-compose-oracle.yml
@@ -15,6 +15,7 @@ services:
       - HTTPS=FALSE
       - GROUP_ID=target
       - DB_HOST=target
+      - DB_SSL=FALSE
       - DB_TYPE=postgres
       - DB_NAME=target
       - DB_USER=target
@@ -33,6 +34,7 @@ services:
       - HTTPS=FALSE
       - GROUP_ID=source
       - DB_HOST=source
+      - DB_SSL=FALSE
       - DB_TYPE=oracle
       - DB_NAME=XE
       - DB_USER=source

--- a/docker-compose-tls.yml
+++ b/docker-compose-tls.yml
@@ -14,6 +14,7 @@ services:
     environment:
       - GROUP_ID=target
       - DB_HOST=target
+      - DB_SSL=FALSE
       - DB_TYPE=postgres
       - DB_NAME=target
       - DB_USER=target
@@ -32,6 +33,7 @@ services:
     environment:
       - GROUP_ID=source
       - DB_HOST=source
+      - DB_SSL=FALSE
       - DB_TYPE=postgres
       - DB_NAME=source
       - DB_USER=source

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - HTTPS=FALSE
       - GROUP_ID=target
       - DB_HOST=target
+      - DB_SSL=FALSE
       - DB_TYPE=postgres
       - DB_NAME=target
       - DB_USER=target
@@ -31,6 +32,7 @@ services:
       - HTTPS=FALSE
       - GROUP_ID=source
       - DB_HOST=source
+      - DB_SSL=FALSE
       - DB_TYPE=postgres
       - DB_NAME=source
       - DB_USER=source


### PR DESCRIPTION
Creates two new environment variables:
- `DB_SSL`: Defines whether or not to use SSL. Set to `FALSE` to
  disable. Defaults to `TRUE`.
- `DB_CA`: A base64 encoded CA certificate to verify the database's
  certificate against. If no certificate is provided then the
  certificate will not be verified.

As this defaults to enabling SSL/TLS it is a breaking change requiring a
major version bump.