### PR TITLE
Add liveness and readiness probes in the example setup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM quay.io/ukhomeofficedigital/centos-base:latest
 
-RUN yum install -y -q java-1.8.0-openjdk nmap-ncat openssl unzip \
+RUN yum install -y -q java-1.8.0-openjdk nmap-ncat openssl unzip epel-release \
+ && yum install -y -q jq \
  && yum update -y -q \
  && yum clean all \
  && rpm --rebuilddb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/ukhomeofficedigital/centos-base:latest
 
-RUN yum install -y -q java-1.8.0-openjdk nmap-ncat openssl unzip epel-release \
- && yum install -y -q jq \
+RUN yum install -y -q epel-release \
+ && yum install -y -q java-1.8.0-openjdk nmap-ncat openssl unzip jq \
  && yum update -y -q \
  && yum clean all \
  && rpm --rebuilddb \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -151,6 +151,7 @@ esac
 
 # Configure according to environment variables
 cat << EOL > "./conf/symmetric-server.properties"
+rest.api.enable=true
 host.bind.name=${LISTEN_HOST}
 http.enable=${HTTP_ENABLE}
 http.port=${HTTP_PORT}
@@ -162,6 +163,7 @@ jmx.http.port=31416
 EOL
 
 cat << EOL > "./engines/${ENGINE_NAME}-${EXTERNAL_ID}.properties"
+rest.api.enable=true
 engine.name=${ENGINE_NAME}
 group.id=${GROUP_ID}
 external.id=${EXTERNAL_ID}

--- a/k8s/target.yaml
+++ b/k8s/target.yaml
@@ -54,6 +54,19 @@ spec:
             - containerPort: 31415
               name: symmetricds
               protocol: TCP
+          livenessProbe:
+            exec:
+              - /bin/sh
+              - -c
+              - ! curl http://127.0.0.1:31415/api/engine/node | grep batchInErrorCount
+            initialDelaySeconds: 60
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /api/engine/node
+              port: 31415
+            initialDelaySeconds: 60
+            timeoutSeconds: 1
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/target.yaml
+++ b/k8s/target.yaml
@@ -54,16 +54,15 @@ spec:
             - containerPort: 31415
               name: symmetricds
               protocol: TCP
-          livenessProbe:
+          readinessProbe:
             exec:
-              - /bin/sh
-              - -c
-              - ! curl http://127.0.0.1:31415/api/engine/node | grep batchInErrorCount
+              command:
+                - "/readinessProbe.sh"
             initialDelaySeconds: 60
             timeoutSeconds: 1
-          readinessProbe:
+          livenessProbe:
             httpGet:
-              path: /api/engine/node
+              path: /api/engine/status
               port: 31415
             initialDelaySeconds: 60
             timeoutSeconds: 1

--- a/readinessProbe.sh
+++ b/readinessProbe.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 set -eo pipefail
 
-curl -H "Accept: application/json" http://127.0.0.1:31415/api/engine/status | jq -e '.started == true'
+LISTEN_PORT="${LISTEN_PORT}"
+HTTPS="${HTTPS:-TRUE}"
+
+if [ "${HTTPS}" == "FALSE" ]; then
+  LISTEN_PORT="${LISTEN_PORT:-31415}"
+else
+  LISTEN_PORT="${LISTEN_PORT:-31417}"
+fi
+
+curl -H "Accept: application/json" http://127.0.0.1:${LISTEN_PORT}/api/engine/status | jq -e '.started == true'

--- a/readinessProbe.sh
+++ b/readinessProbe.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eo pipefail
+
+curl -H "Accept: application/json" http://127.0.0.1:31415/api/engine/status | jq -e '.started == true'


### PR DESCRIPTION
Enable the REST api in order to be able to check the status of those endpoints