### PR TITLE
[LEVWEB-983] Fix: Use PEM version of Postgres CA

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,11 +92,10 @@ else
     cd security
     rm cacerts
     mkdir -p .cacerts
-    echo -n "${HTTPS_CA_BUNDLE}" | base64 -d > .cacerts/bundle
+    echo -n "${HTTPS_CA_BUNDLE}" | base64 -d > .cacerts/https.pem
     keytool -importcert -noprompt \
             -keystore cacerts -storepass "${p}" -storetype jks \
-            -file .cacerts/bundle
-    rm -rf .cacerts
+            -file .cacerts/https.pem
     cd ..
   fi
 fi
@@ -104,11 +103,10 @@ fi
 if [ -n "${DB_CA}" ]; then
     cd security
     mkdir -p .cacerts
-    echo -n "${DB_CA}" | base64 -d > .cacerts/db-ca
+    echo -n "${DB_CA}" | base64 -d > .cacerts/db.pem
     keytool -importcert -noprompt \
             -keystore cacerts -storepass "${p}" -storetype jks \
-            -file .cacerts/db-ca
-    rm -rf .cacerts
+            -file .cacerts/db.pem
     cd ..
 fi
 
@@ -146,7 +144,7 @@ case "${DB_TYPE}" in
     JDBC_DRIVER="org.postgresql.Driver"
     if [ "${DB_SSL}" != "FALSE" ]; then
         if [ -n "${DB_CA}" ]; then
-            JDBC_URL_PARAMS="?ssl=true&sslrootcert=${PWD}/security/cacerts&sslmode=verify-full"
+            JDBC_URL_PARAMS="?ssl=true&sslrootcert=${PWD}/security/.cacerts/db.pem&sslmode=verify-full"
         else
             JDBC_URL_PARAMS="?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory"
         fi


### PR DESCRIPTION
A bug was introduced in the last commit in which the CA for PostgreSQL
was referenced in JKS format which is not supported. This fixes the bug
by doing the following:

1. Allowing the `.cacerts` directory to persist to allow constituent PEM
files to be referenced directly.
2. Disambiguating the constituent PEM files into HTTPS and database.
3. Correcting the Postgres code to reference the PEM file for the
database.

The bug was introduced here: https://github.com/UKHomeOffice/docker-symmetricds/pull/30/files#diff-b958f585a04af5ee2087610ea7180f34L143