### PR TITLE
Fix: Don't verify certificate in readiness probe

### DIFF
--- a/readiness.sh
+++ b/readiness.sh
@@ -18,4 +18,4 @@ fi
 
 port="${LISTEN_PORT:-${default_port}}"
 
-curl -fsSH "Accept: application/json" "${protocol}://127.0.0.1:${port}/api/engine/status" | jq -e '.started == true'
+curl -fskSH "Accept: application/json" "${protocol}://127.0.0.1:${port}/api/engine/status" | jq -e '.started == true'


### PR DESCRIPTION
We don't care whether the certificate is trusted or not in the readiness
probe as we are just talking to localhost and the certificate will
usually be self-signed.