### PR TITLE
[LEVWEB-1043] Put Basic Auth on all endpoints

### DIFF
--- a/docker-compose-basic-auth.yml
+++ b/docker-compose-basic-auth.yml
@@ -57,6 +57,7 @@ services:
       - HTTPS=FALSE
       - GROUP_ID=source
       - DB_HOST=source
+      - DB_SSL=FALSE
       - DB_TYPE=postgres
       - DB_NAME=source
       - DB_USER=source

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -180,7 +180,7 @@ fi
 
 if [[ -n "${USERNAME}" && -n "${PASSWORD}" ]]; then
   # basic auth setup!!
-  sed -i "s|</web-app>|<security-constraint><web-resource-collection><url-pattern>/sync/*</url-pattern></web-resource-collection><auth-constraint><role-name>user</role-name></auth-constraint></security-constraint><login-config><auth-method>BASIC</auth-method><realm-name>default</realm-name></login-config></web-app>|" ./web/WEB-INF/web.xml
+  sed -i "s|</web-app>|<security-constraint><web-resource-collection><url-pattern>/*</url-pattern></web-resource-collection><auth-constraint><role-name>user</role-name></auth-constraint></security-constraint><login-config><auth-method>BASIC</auth-method><realm-name>default</realm-name></login-config></web-app>|" ./web/WEB-INF/web.xml
 
   echo -n "${USERNAME}: ${PASSWORD},user" >> ./web/WEB-INF/realm.properties
 

--- a/readiness.sh
+++ b/readiness.sh
@@ -6,9 +6,15 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Defaults
 default_port="31417"
 protocol="https"
+auth=""
 
 # Environment variables
 source "${SCRIPT_DIR}/env.cfg"
+
+# Set-up param for auth
+if [ -n "${USERNAME}" ]; then
+  auth="-u ${USERNAME}:${PASSWORD}"
+fi
 
 # Handle non-HTTPS case
 if [ "${HTTPS}" == "FALSE" ]; then
@@ -18,4 +24,4 @@ fi
 
 port="${LISTEN_PORT:-${default_port}}"
 
-curl -fskSH "Accept: application/json" "${protocol}://127.0.0.1:${port}/api/engine/status" | jq -e '.started == true'
+curl -fskSH "Accept: application/json" ${auth} "${protocol}://127.0.0.1:${port}/api/engine/status" | jq -e '.started == true'


### PR DESCRIPTION
Previously auth was only placed on the `/sync/` endpoints.

*Note:* This change means that the readiness check needs to provide
credentials.