### PR TITLE
Only push Release Candidate tags

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -45,6 +45,8 @@ tag_n_push() {
 }
 
 tag_n_push "${PATCH}"
-tag_n_push "${MINOR}"
-tag_n_push "${MAJOR}"
-tag_n_push "latest"
+if echo "${PATCH}" | grep -qvP '^v?\d+\.\d+\.\d+-rc\d*$' ; then
+    tag_n_push "${MINOR}"
+    tag_n_push "${MAJOR}"
+    tag_n_push "latest"
+fi


### PR DESCRIPTION
When the release version signifies a release candidate (e.g. `v3.4.24-rc`, `v3.4.24-rc12`, etc), do not push the extra tags (from the previous examples: `v3`, `v3.4`, `latest`).