### PR TITLE
MySQL no SSL fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN MINOR=`echo "${SYMMETRICDS_VERSION}" | sed 's/\.[^.]*$//'` \
  && unzip 'symmetricds.zip' \
  && rm 'symmetricds.zip' \
  && ln -s "symmetric-server-${SYMMETRICDS_VERSION}/" 'symmetric-server'
+ 
+RUN rm symmetric-server/lib/mysql-connector-java-*.jar \
+ && curl -L -o 'symmetric-server/lib/mysql-connector-java-8.0.20.jar' "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.20/mysql-connector-java-8.0.20.jar"
 
 COPY entrypoint.sh env.cfg liveness.sh readiness.sh /app/
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -123,6 +123,8 @@ case "${DB_TYPE}" in
         else
             JDBC_URL_PARAMS="?useSSL=true&requireSSL=true&verifyServerCertificate=false"
         fi
+    else
+        JDBC_URL_PARAMS="?allowPublicKeyRetrieval=true&useSSL=false"
     fi
     JDBC_URL="jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}${JDBC_URL_PARAMS}"
     echo "Warning: There appears to be a bug in MySQL support."
@@ -147,6 +149,8 @@ case "${DB_TYPE}" in
         else
             JDBC_URL_PARAMS="?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory"
         fi
+    else
+        JDBC_URL_PARAMS="?ssl=false"
     fi
     JDBC_URL="jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}${JDBC_URL_PARAMS}"
     ;;


### PR DESCRIPTION
Adds support for MySQL DBs that don't use SSL connections, and in doing so allows the `docker-compose-mysql.yml` file to work as expected with:
```shell
docker-compose -f docker-compose-mysql.yml up
```
This fixes issue: https://github.com/UKHomeOffice/docker-symmetricds/issues/46